### PR TITLE
Make the website look less broken in Safari

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,9 +1,9 @@
 .desc_top {
-    position: absolute;
+    position: fixed;
     top: -3em;
 }
 .desc_bottom {
-    position: absolute;
+    position: fixed;
     top: 3em;
 }
 .node {
@@ -13,7 +13,6 @@
     justify-content: center;
     align-items: center;
     border-radius: 5px;
-    position: absolute;
     z-index: 99;
 }
 .highlight {

--- a/docs/tree.js
+++ b/docs/tree.js
@@ -1940,7 +1940,7 @@ var data = [{
         father: 52,
         alias: "ZombieLoad v4",
         img: "zombieload.svg",
-        description: "SGX-enabled processors trigger a microcode assist whenever an address translationresolves into SGX's Processor Reserved Memory (PRM) area and the CPU is outside enclave mode. While this ensures that the load instruction always reads 0xff at the architectural level, we found however that unauthorized line-fill buffer entries accessed by the sibling logical core may still be transiently dereferenced before abort page semantics are applied.",
+        description: "SGX-enabled processors trigger a microcode assist whenever an address translation resolves into SGX's Processor Reserved Memory (PRM) area and the CPU is outside enclave mode. While this ensures that the load instruction always reads 0xff at the architectural level, we found however that unauthorized line-fill buffer entries accessed by the sibling logical core may still be transiently dereferenced before abort page semantics are applied.",
         todo: "We encourage investigation of using SGX processor-reserved memory to leak data from other buffers.",
         sources: [
             sources["Schwarz2019"],


### PR DESCRIPTION
Today in "what does WebKit do completely wrong" SVGs with `foreignObject` does not handle `position: absolute` correctly. It kind works if you get make the changes here, and it looked the same in Firefox when I tried it so hopefully this is a net improvement.